### PR TITLE
Add health check endpoint to web server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN pip install -r requirements.txt
 
 EXPOSE 5000
 
-HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "pgrep -f main.py || exit 1" ]
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl --silent --fail http://localhost:5000/health || exit 1
 
 CMD ["python", "./main.py"]

--- a/main.py
+++ b/main.py
@@ -4,11 +4,14 @@ The main process for the NHL twitter bot application.
 
 import threading
 import logging
+import signal
+
 from os import path
 from flask import Flask
 from waitress import serve
 
 from src import bot
+from src import logger
 
 app = Flask(__name__)
 
@@ -27,6 +30,24 @@ def home():
     with open("bot.log", encoding="utf-8") as log_file:
         return "<xmp>" + log_file.read() + "</xmp>"
 
+@app.route('/health')
+def health():
+    """
+    Health check endpoint.
+    """
+    if not bot.check_health():
+        return "Health check failed", 503
+    return "Healthy", 200
+
+def shutdown(signum, frame):
+    """
+    Shutdown the bot and the web application.
+    """
+    logger.log.info("Shutting down...")
+    exit(0)
+
+signal.signal(signal.SIGTERM, shutdown)
+
 if __name__ == '__main__':
 
     # Run the twitter bot in the background
@@ -34,4 +55,4 @@ if __name__ == '__main__':
     bot_thread.start()
 
     # Run the front-end web application
-    serve(app, host="0.0.0.0", port=5000, threads=8)
+    serve(app, host="0.0.0.0", port=5000, _quiet=True)

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ The main process for the NHL twitter bot application.
 import threading
 import logging
 import signal
+import sys
 
 from os import path
 from flask import Flask
@@ -39,12 +40,12 @@ def health():
         return "Health check failed", 503
     return "Healthy", 200
 
-def shutdown(signum, frame):
+def shutdown(_signum, _frame):
     """
     Shutdown the bot and the web application.
     """
     logger.log.info("Shutting down...")
-    exit(0)
+    sys.exit(0)
 
 signal.signal(signal.SIGTERM, shutdown)
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -10,6 +10,7 @@ import pause
 from src import schedule
 from src.command.command_queue import command_queue
 from src.command.check_game_status import CheckGameStatus
+from src.command.check_health import CheckHealth
 from src.game_thread import GameThread
 from src.logger import log
 from src.output import output
@@ -37,6 +38,17 @@ def check_game_status() -> None:
         command_queue.enqueue(CheckGameStatus(threads.get()))
         pause.seconds(30)
     log.info("Exiting status thread")
+
+
+def check_health() -> bool:
+    """
+    Check the health of the application by enqueueing a command and
+    ensuring that it is processed in a reasonable amount of time.
+    """
+    health_check = CheckHealth()
+    command_queue.enqueue(health_check)
+    result = health_check.event.wait(1)
+    return result
 
 
 def check_for_updates() -> None:

--- a/src/command/check_health.py
+++ b/src/command/check_health.py
@@ -1,0 +1,33 @@
+"""
+This module defines the application health check command.
+"""
+
+import threading
+
+from src.command.command import Command, Priority
+from src.logger import log
+
+# pylint: disable=too-few-public-methods
+class CheckHealth(Command):
+    """
+    This class defines the Post Highlight command.
+    """
+
+    def __init__(self):
+        super().__init__("Check Health", Priority.HIGH)
+        self._event = threading.Event()
+
+
+    def execute(self) -> None:
+        """
+        Execute the command.
+        """
+        log.info("Checking health of application.")
+        self._event.set()
+
+    @property
+    def event(self) -> threading.Event:
+        """
+        Return the event for the command.
+        """
+        return self._event

--- a/src/command/post_reply.py
+++ b/src/command/post_reply.py
@@ -32,7 +32,7 @@ class PostReply(Command):
             return
 
         if self.previous.event is None:
-            log.error("Could find event for highlight: " + str(self.previous))
+            log.error("Could not find event for highlight: " + str(self.previous))
             return
 
         text : Optional[str] = self.updated.get_reply(self.previous.event)

--- a/src/parser/content.py
+++ b/src/parser/content.py
@@ -61,5 +61,6 @@ class ContentParser(Parser):
                 else:
                     previous : Optional[Highlight] = self.highlight_list.get(highlight.id)
                     if previous is not None and previous.event != highlight.event:
+                        log.info("Updating existing highlight: " + str(highlight.id))
                         self.highlight_list.update(highlight)
                         command_queue.enqueue(PostReply(highlight, previous))


### PR DESCRIPTION
Adds a new `/health` endpoint to the Flask web server. This is used in the Docker container's health check. When we receive a request at this endpoint, we'll enqueue a new command on the queue. This command simply has to be executed (ie: reach the front of the queue) for it to be considered a health check. We essentially just want to make sure that the command queue is still processing commands.