### PR TITLE
Handle decode errors when parsing (likely caused by lack of browser headers

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -49,6 +49,13 @@ class Logger:
         self.logger.error(msg)
 
 
+    def warning(self, msg):
+        """
+        Log the given message at the warning level.
+        """
+        self.logger.warning(msg)
+
+
     def verbose(self, msg):
         """
         Log the given message at the debug level.

--- a/src/output/bluesky.py
+++ b/src/output/bluesky.py
@@ -194,7 +194,7 @@ class BlueSky(Outputter):
             return None
 
         if text in self.posts:
-            log.error("Bluesky - Skipping duplicate post")
+            log.warning("Bluesky - Skipping duplicate post")
             return None
 
         post : dict[Any, Any] = {
@@ -223,7 +223,7 @@ class BlueSky(Outputter):
             return None
 
         if text in self.posts:
-            log.error("Bluesky - Skipping duplicate post")
+            log.warning("Bluesky - Skipping duplicate post")
             return None
 
         if "cid" not in parent or "uri" not in parent:
@@ -310,7 +310,7 @@ class BlueSky(Outputter):
             return None
 
         if utils.strip_text(text) in self.posts:
-            log.error("Bluesky - Skipping duplicate post: " + utils.strip_text(text))
+            log.warning("Bluesky - Skipping duplicate post: " + utils.strip_text(text))
             return None
 
         blob = self.upload_video(media)
@@ -352,7 +352,7 @@ class BlueSky(Outputter):
             return None
 
         if utils.strip_text(text) in self.posts:
-            log.error("Bluesky - Skipping duplicate post: " + utils.strip_text(text))
+            log.warning("Bluesky - Skipping duplicate post: " + utils.strip_text(text))
             return None
 
         if "cid" not in parent or "uri" not in parent:

--- a/src/output/tweeter.py
+++ b/src/output/tweeter.py
@@ -120,7 +120,7 @@ class Tweeter(Outputter):
             return None
 
         if self.has_posted(text):
-            log.error("Twitter - Skipping duplicate post: " + utils.strip_text(text))
+            log.warning("Twitter - Skipping duplicate post: " + utils.strip_text(text))
             return None
 
         try:
@@ -157,7 +157,7 @@ class Tweeter(Outputter):
             return None
 
         if self.has_posted(text):
-            log.error("Twitter - Skipping duplicate post: " + utils.strip_text(text))
+            log.warning("Twitter - Skipping duplicate post: " + utils.strip_text(text))
             return None
 
         try:
@@ -204,7 +204,7 @@ class Tweeter(Outputter):
             return None
 
         if self.has_posted(text):
-            log.error("Twitter - Skipping duplicate post: " + utils.strip_text(text))
+            log.warning("Twitter - Skipping duplicate post: " + utils.strip_text(text))
             return None
 
         try:
@@ -251,7 +251,7 @@ class Tweeter(Outputter):
             return None
 
         if self.has_posted(text):
-            log.error("Twitter - Skipping duplicate post: " + utils.strip_text(text))
+            log.warning("Twitter - Skipping duplicate post: " + utils.strip_text(text))
             return None
 
         try:

--- a/src/parser/parser.py
+++ b/src/parser/parser.py
@@ -1,9 +1,13 @@
 """
-This  defines the interface for data parsers.
+This defines the interface for data parsers.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Optional
+import time
+import random
+import gzip
+import json
 
 import requests
 import requests.utils
@@ -11,40 +15,132 @@ import requests.structures
 
 from src.logger import log
 
-NHL_API_URL : str = "https://api-web.nhle.com/v1/gamecenter/"
+NHL_API_URL: str = "https://api-web.nhle.com/v1/gamecenter/"
+
+BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Referer": "https://www.nhl.com/",
+    "Origin": "https://www.nhl.com",
+}
+
+MAX_ATTEMPTS = 4
+BASE_SLEEP = 0.4
+
 
 class Parser(ABC):
     """
-    This class defines the interface for data parsers.
+    Base class for NHL API data parsers. Handles retrieval, decoding, retry logic,
+    and defensive checks for CDN anomalies. Subclasses implement parse() to convert
+    raw API JSON into structured domain-specific objects.
     """
 
-    def __init__(self, game_id : int, path : str, base_url : str = NHL_API_URL) -> None:
-        self.game_id : int = game_id
-        self.url     : str = base_url + str(game_id) + path
-        self.data    : Any = {}
+    def __init__(self, game_id: int, path: str,
+                 base_url: str = NHL_API_URL) -> None:
+        self.game_id: int = game_id
+        self.url: str = base_url + str(game_id) + path
+        self.data: Any = {}
         log.verbose("Parsing from: " + self.url)
 
+    def _sleep_backoff(self, attempt: int) -> None:
+        sleep_time = BASE_SLEEP * (2 ** (attempt - 1))
+        sleep_time += random.uniform(0.05, 0.25)
+        time.sleep(sleep_time)
+
+    def _fetch_json_with_retry(self) -> Optional[Any]:
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            try:
+                resp = requests.get(
+                    self.url,
+                    headers=BROWSER_HEADERS,
+                    timeout=10,
+                )
+            except requests.exceptions.Timeout:
+                log.error(
+                    f"Timeout occurred while pulling data from: {self.url}"
+                )
+                self._sleep_backoff(attempt)
+                continue
+            except requests.exceptions.ConnectionError:
+                log.error(
+                    f"Connection error occurred while pulling data from: "
+                    f"{self.url}"
+                )
+                self._sleep_backoff(attempt)
+                continue
+
+            body = resp.content
+            if not body or len(body) < 50:
+                log.error(
+                    f"Body too small ({len(body)} bytes) while pulling data "
+                    f"from: {self.url}"
+                )
+                self._sleep_backoff(attempt)
+                continue
+
+            raw = body
+            if raw.startswith(b"\x1f\x8b\x08"):
+                try:
+                    raw = gzip.decompress(raw)
+                except OSError as e:
+                    log.error(
+                        f"Gzip decode error from {self.url}: {e}"
+                    )
+                    self._sleep_backoff(attempt)
+                    continue
+
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError as e:
+                snippet = raw[:200].decode(errors="ignore")
+                log.error(
+                    f"Unicode decode error from {self.url}: {e} | "
+                    f"snippet: {snippet}"
+                )
+                self._sleep_backoff(attempt)
+                continue
+
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError as e:
+                snippet = text[:200]
+                log.error(
+                    f"JSON decode error while pulling data from {self.url}: "
+                    f"{e} | snippet: {snippet}"
+                )
+                self._sleep_backoff(attempt)
+                continue
+            except ValueError as e:
+                snippet = text[:200]
+                log.error(
+                    f"Invalid JSON structure from {self.url}: {e} | "
+                    f"snippet: {snippet}"
+                )
+                self._sleep_backoff(attempt)
+                continue
+
+        log.error(f"All attempts to fetch data from {self.url} failed.")
+        return None
 
     def get_data(self) -> None:
         """
-        This function retrieves the latest JSON data record for the current
-        game from the NHL website.
+        Retrieve JSON data for the associated game. Handles retries, CDN anomalies,
+        decode failures, and assigns the parsed result to self.data. If retrieval
+        fails after all attempts, self.data is set to an empty dict.
         """
-        params  : str = ""
-        headers : requests.structures.CaseInsensitiveDict = requests.utils.default_headers()
-        try:
-            request : Any = requests.get(self.url, headers=headers, params=params, timeout=10)
-            self.data = request.json()
-        except requests.exceptions.Timeout:
-            log.error("Timeout occurred while pulling data from: " + self.url)
-        except requests.exceptions.ConnectionError:
-            log.error("Connection error occurred while pulling data from: " + self.url)
-        except requests.exceptions.JSONDecodeError:
-            log.error("Decode error occurred while pulling data from: " + self.url)
-
+        result = self._fetch_json_with_retry()
+        if result is None:
+            log.error(f"Game data is null for game: {self.game_id}")
+            self.data = {}
+        else:
+            self.data = result
 
     @abstractmethod
     def parse(self):
         """
-        Parse the data pulled by the data request and convert it to a usable form.
+        Parse the fetched JSON data.
         """


### PR DESCRIPTION
Started getting a decode error when parsing the NHL API data recently. Worked fine in the browser, so I'm guessing is related to headers in the request. Added new headers to the request to prevent this error and generally cleaned up the error handling in the parser class.