### PR TITLE
Fix Bluesky hashtag facets to use UTF-8 byte offsets

### DIFF
--- a/src/output/bluesky.py
+++ b/src/output/bluesky.py
@@ -5,6 +5,7 @@ authenticate, post and reply.
 
 import os
 import time
+import re
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -39,22 +40,27 @@ def now() -> str:
     """
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
+HASHTAG_RE = re.compile(r"#\w+")
 
-def get_tag_indices(text : str) -> List[tuple[int,int]]:
+def get_tag_indices(text: str) -> list[tuple[int, int]]:
     """
     Bluesky doesn't just automatically parse hashtag locations,
     so you need to parse the text of your post and find any hashtags.
     Then you need to return the start and end indices of each
     hashtag. This is then sent in the post request as a facet.
     """
-    indices : List[tuple[int,int]] = []
-    for word in text.split():
-        if word.startswith("#"):
-            start = text.find(word)
-            end   = start + len(word)
-            indices.append((start, end))
-    return indices
 
+    indices: list[tuple[int, int]] = []
+
+    for match in HASHTAG_RE.finditer(text):
+        char_start, char_end = match.span()
+
+        byte_start = len(text[:char_start].encode("utf-8"))
+        byte_end = len(text[:char_end].encode("utf-8"))
+
+        indices.append((byte_start, byte_end))
+
+    return indices
 
 def parse_tags(text : str) -> List:
     """
@@ -72,7 +78,7 @@ def parse_tags(text : str) -> List:
             "features": [
                 {
                     "$type": "app.bsky.richtext.facet#tag",
-                    "tag": text[start+1:end]
+                    "tag": text.encode("utf-8")[start:end].decode("utf-8")[1:]
                 }
             ]})
     return facets

--- a/test/data/test_event.py
+++ b/test/data/test_event.py
@@ -1,115 +1,213 @@
 """
-TODO
+Unit tests for src.data.event
 """
 
 import unittest
 from typing import Any, Optional
 
 from src.data import event
+from src.data.period import Period
 
-class TestAbbreviations(unittest.TestCase):
+
+def make_period(number: int = 1) -> Period:
     """
-    TODO
+    Create a minimal valid Period instance for tests.
     """
+    return Period(number, {
+        "periodType": "REG",
+        "periodNumber": number,
+    })
+
+
+def base_event_data(**overrides) -> dict:
+    """
+    Minimal valid event payload for Event construction.
+    """
+    data = {
+        "timeInPeriod": "01:00",
+        "homeScore": 0,
+        "awayScore": 0,
+    }
+    data.update(overrides)
+    return data
+
+
+class TestEvent(unittest.TestCase):
+    """
+    Tests for play-by-play event parsing helpers and Event behavior.
+    """
+
+    # ---------- to_name ----------
 
     def test_to_name(self):
-        """
-        TODO
-        """
-        data : Any = {
+        data: Any = {
             "playerId": 8477942,
             "firstName": {"default": "Kevin"},
             "lastName": {"default": "Fiala"},
-            "assistToDate": 1
+            "assistToDate": 1,
         }
-        expected : Optional[str] = "Kevin Fiala"
-        actual   : Optional[str] = event.to_name(data)
-        assert expected == actual
- 
+        expected: Optional[str] = "Kevin Fiala"
+        actual: Optional[str] = event.to_name(data)
+        self.assertEqual(expected, actual)
+
+    def test_to_name_missing_fields(self):
+        self.assertIsNone(event.to_name({"firstName": {"default": "Kevin"}}))
+        self.assertIsNone(event.to_name({"lastName": {"default": "Fiala"}}))
+        self.assertIsNone(event.to_name({}))
+
+    # ---------- primary assist ----------
+
     def test_get_primary_assist(self):
-        """
-        TODO
-        """
-        data : Any = {
+        data: Any = {
             "assists": [
                 {
                     "playerId": 8477942,
                     "firstName": {"default": "Kevin"},
                     "lastName": {"default": "Fiala"},
-                    "assistToDate": 1
                 },
                 {
                     "playerId": 8481606,
                     "firstName": {"default": "Jordan"},
                     "lastName": {"default": "Spence"},
-                    "assistToDate": 1
-                }
+                },
             ]
         }
-        expected : str           = "Kevin Fiala"
-        actual   : Optional[str] = event.get_primary_assist(data)
-        assert expected == actual
-
+        expected: str = "Kevin Fiala"
+        actual: Optional[str] = event.get_primary_assist(data)
+        self.assertEqual(expected, actual)
 
     def test_get_invalid_primary_assist(self):
-        """
-        TODO
-        """
-        data     : Any           = {}
-        expected : Optional[str] = None
-        actual   : Optional[str] = event.get_primary_assist(data)
-        assert expected == actual
+        self.assertIsNone(event.get_primary_assist({}))
 
+    # ---------- secondary assist ----------
 
     def test_get_secondary_assist(self):
-        """
-        TODO
-        """
-        data : Any = {
+        data: Any = {
             "assists": [
                 {
                     "playerId": 8477942,
                     "firstName": {"default": "Kevin"},
                     "lastName": {"default": "Fiala"},
-                    "assistToDate": 1
                 },
                 {
                     "playerId": 8481606,
                     "firstName": {"default": "Jordan"},
                     "lastName": {"default": "Spence"},
-                    "assistToDate": 1
-                }
+                },
             ]
         }
-        expected : str           = "Jordan Spence"
-        actual   : Optional[str] = event.get_secondary_assist(data)
-        assert expected == actual
-
+        expected: str = "Jordan Spence"
+        actual: Optional[str] = event.get_secondary_assist(data)
+        self.assertEqual(expected, actual)
 
     def test_get_invalid_secondary_assist(self):
-        """
-        TODO
-        """
-        data     : Any           = {}
-        expected : Optional[str] = None
-        actual   : Optional[str] = event.get_secondary_assist(data)
-        assert expected == actual
-
+        self.assertIsNone(event.get_secondary_assist({}))
 
     def test_get_missing_secondary_assist(self):
-        """
-        TODO
-        """
-        data : Any = {
+        data: Any = {
             "assists": [
                 {
-                    "playerId": 8477942,
                     "firstName": {"default": "Kevin"},
                     "lastName": {"default": "Fiala"},
-                    "assistToDate": 1
                 }
             ]
         }
-        expected : Optional[str] = None
-        actual   : Optional[str] = event.get_secondary_assist(data)
-        assert expected == actual
+        self.assertIsNone(event.get_secondary_assist(data))
+
+    # ---------- team ----------
+
+    def test_get_team_valid(self):
+        data = {"teamAbbrev": {"default": "EDM"}}
+        self.assertEqual("Edmonton", event.get_team(data))
+
+    def test_get_team_invalid(self):
+        self.assertIsNone(event.get_team({"teamAbbrev": {"default": "XXX"}}))
+
+    def test_get_team_missing(self):
+        self.assertIsNone(event.get_team({}))
+
+    # ---------- strength ----------
+
+    def test_get_strength(self):
+        self.assertEqual("powerPlay", event.get_strength({"strength": "powerPlay"}))
+
+    def test_get_strength_missing(self):
+        self.assertIsNone(event.get_strength({}))
+
+    # ---------- empty net ----------
+
+    def test_is_empty_net_true(self):
+        self.assertTrue(event.is_empty_net({"goalModifier": "empty-net"}))
+
+    def test_is_empty_net_false(self):
+        self.assertFalse(event.is_empty_net({"goalModifier": "deflected"}))
+
+    def test_is_empty_net_missing(self):
+        self.assertFalse(event.is_empty_net({}))
+
+    # ---------- time remaining ----------
+
+    def test_get_time_remaining(self):
+        period = make_period(1)
+        data = {"timeInPeriod": "05:30"}
+        self.assertEqual("14:30", event.get_time_remaining(period, data))
+
+    # ---------- Event comparison logic ----------
+
+    def test_is_scorer_modified(self):
+        period = make_period(1)
+
+        prev = event.Event(period, base_event_data(
+            firstName={"default": "Connor"},
+            lastName={"default": "McDavid"},
+        ))
+
+        curr = event.Event(period, base_event_data(
+            firstName={"default": "Leon"},
+            lastName={"default": "Draisaitl"},
+        ))
+
+        self.assertTrue(curr.is_scorer_modified(prev))
+
+    def test_primary_assist_added(self):
+        period = make_period(1)
+
+        prev = event.Event(period, base_event_data())
+
+        curr = event.Event(period, base_event_data(
+            assists=[
+                {
+                    "firstName": {"default": "Kevin"},
+                    "lastName": {"default": "Fiala"},
+                }
+            ]
+        ))
+
+        self.assertTrue(curr.is_primary_assist_added(prev))
+
+    def test_secondary_assist_added(self):
+        period = make_period(1)
+
+        prev = event.Event(period, base_event_data(
+            assists=[
+                {
+                    "firstName": {"default": "Kevin"},
+                    "lastName": {"default": "Fiala"},
+                }
+            ]
+        ))
+
+        curr = event.Event(period, base_event_data(
+            assists=[
+                {
+                    "firstName": {"default": "Kevin"},
+                    "lastName": {"default": "Fiala"},
+                },
+                {
+                    "firstName": {"default": "Jordan"},
+                    "lastName": {"default": "Spence"},
+                },
+            ]
+        ))
+
+        self.assertTrue(curr.is_secondary_assist_added(prev))

--- a/test/output/test_bluesky_facets.py
+++ b/test/output/test_bluesky_facets.py
@@ -1,0 +1,144 @@
+import pytest
+
+from src.output.bluesky import get_tag_indices, parse_tags
+
+
+class TestBlueskyFacets:
+
+    def test_single_ascii_hashtag(self):
+        text = "Goal by #McDavid"
+
+        indices = get_tag_indices(text)
+        assert indices == [
+            (
+                len("Goal by ".encode("utf-8")),
+                len("Goal by #McDavid".encode("utf-8")),
+            )
+        ]
+
+        facets = parse_tags(text)
+        assert len(facets) == 1
+        assert facets[0]["features"][0]["tag"] == "McDavid"
+
+    def test_emoji_before_hashtag(self):
+        text = "🚨 GOAL 🚨 by #McDavid"
+
+        indices = get_tag_indices(text)
+
+        byte_start = len("🚨 GOAL 🚨 by ".encode("utf-8"))
+        byte_end = len("🚨 GOAL 🚨 by #McDavid".encode("utf-8"))
+
+        assert indices == [(byte_start, byte_end)]
+
+    def test_accented_characters(self):
+        text = "But à Montréal par #Suzuki"
+
+        indices = get_tag_indices(text)
+
+        byte_start = len("But à Montréal par ".encode("utf-8"))
+        byte_end = len("But à Montréal par #Suzuki".encode("utf-8"))
+
+        assert indices == [(byte_start, byte_end)]
+
+    def test_multiple_hashtags(self):
+        text = "🚨 #McDavid scores for the #Oilers"
+
+        indices = get_tag_indices(text)
+
+        expected = [
+            (
+                len("🚨 ".encode("utf-8")),
+                len("🚨 #McDavid".encode("utf-8")),
+            ),
+            (
+                len("🚨 #McDavid scores for the ".encode("utf-8")),
+                len("🚨 #McDavid scores for the #Oilers".encode("utf-8")),
+            ),
+        ]
+
+        assert indices == expected
+
+    def test_duplicate_hashtags(self):
+        text = "#Goal by #Goal scorer"
+
+        indices = get_tag_indices(text)
+
+        assert len(indices) == 2
+        assert indices[0] != indices[1]
+
+        facets = parse_tags(text)
+        assert facets[0]["features"][0]["tag"] == "Goal"
+        assert facets[1]["features"][0]["tag"] == "Goal"
+
+    def test_facet_byte_ranges_map_correctly(self):
+        text = "🚨 GOAL by #McDavid"
+
+        facets = parse_tags(text)
+        assert len(facets) == 1
+
+        facet = facets[0]
+        start = facet["index"]["byteStart"]
+        end = facet["index"]["byteEnd"]
+
+        extracted = (
+            text.encode("utf-8")[start:end]
+            .decode("utf-8")
+        )
+
+        assert extracted == "#McDavid"
+
+    def test_get_tag_indices_single(self):
+        text = "This is a #test"
+
+        byte_start = len("This is a ".encode("utf-8"))
+        byte_end = len("This is a #test".encode("utf-8"))
+
+        expected = [(byte_start, byte_end)]
+        actual = get_tag_indices(text)
+
+        assert expected == actual
+
+    def test_get_tag_indices_multiple(self):
+        text = "#Hello world! This is a #test of #tags"
+
+        expected = [
+            (
+                len("".encode("utf-8")),
+                len("#Hello".encode("utf-8")),
+            ),
+            (
+                len("#Hello world! This is a ".encode("utf-8")),
+                len("#Hello world! This is a #test".encode("utf-8")),
+            ),
+            (
+                len("#Hello world! This is a #test of ".encode("utf-8")),
+                len("#Hello world! This is a #test of #tags".encode("utf-8")),
+            ),
+        ]
+
+        actual = get_tag_indices(text)
+        assert expected == actual
+
+    def test_get_tag_indices_none(self):
+        text = "This text has no tags."
+        assert get_tag_indices(text) == []
+
+    def test_parse_tags_single(self):
+        text = "This is a #test"
+
+        facets = parse_tags(text)
+
+        assert len(facets) == 1
+        assert facets[0]["features"][0]["tag"] == "test"
+
+    def test_parse_tags_multiple(self):
+        text = "#Hello world! This is a #test of #tags"
+
+        facets = parse_tags(text)
+
+        tags = [f["features"][0]["tag"] for f in facets]
+        assert tags == ["Hello", "test", "tags"]
+
+    def test_parse_tags_none(self):
+        text = "This text has no tags."
+        assert parse_tags(text) == []


### PR DESCRIPTION
Bluesky rich-text facets require UTF-8 byte offsets, but our hashtag parsing was using Python string (character) indices. This caused hashtag facets to be incorrect or silently ignored when posts contained emojis or non-ASCII characters (e.g., accented player names).

**Changes**
- Updated hashtag parsing to calculate byteStart / byteEnd using UTF-8–encoded offsets
- Switched to a regex-based scan to correctly handle duplicate hashtags in the same post
- Added unit tests