### PR TITLE
Address handling of shootout goals; expand unit tests

### DIFF
--- a/src/command/command_queue.py
+++ b/src/command/command_queue.py
@@ -7,6 +7,7 @@ from typing import Optional, List
 
 from src.command.command import Command, Priority
 from src.logger import log
+from src.output.output import output
 
 
 class State(Enum):
@@ -94,6 +95,12 @@ class CommandQueue:
         """
         Stop processing commands from the queue.
         """
+        # In dry run mode we don't actually stop the command server so that
+        # the server remains running for testing and interaction.
+        if output.dry_run:
+            log.info("Dry run enabled; ignoring stop request for command server.")
+            return
+
         self.state = State.STOPPING
         self.enqueue(Shutdown())
 

--- a/src/data/highlight.py
+++ b/src/data/highlight.py
@@ -107,6 +107,8 @@ class Highlight:
 
         if self.event.is_empty_net:
             goal_string = templates.EMPTY_NET_GOAL_TEMPLATE.format(**event_values)
+        elif self.event.period.is_shootout:
+            goal_string = templates.SHOOTOUT_GOAL_TEMPLATE.format(**event_values)
         elif self.event.strength == "pp":
             goal_string = templates.POWER_PLAY_GOAL_TEMPLATE.format(**event_values)
         elif self.event.strength == "sh":

--- a/src/data/period.py
+++ b/src/data/period.py
@@ -9,7 +9,7 @@ from src.data.game_type import GameType
 
 REGULATION : str = "REG"
 OVERTIME   : str = "OT"
-SHOOTOUT   : str = "SHO"
+SHOOTOUT   : str = "SO"
 
 
 class Period:

--- a/src/output/templates.py
+++ b/src/output/templates.py
@@ -27,6 +27,12 @@ Empty net goal for {team}!
 Scored by {scorer} with {time} remaining in the {period} period.
 """
 
+SHOOTOUT_GOAL_TEMPLATE = """\
+{team} goal!
+
+Scored by {scorer} in the shootout.
+"""
+
 SCORE_TEMPLATE = """
 {home_team}: {home_goals}
 {away_team}: {away_goals}

--- a/test/data/test_abbreviations.py
+++ b/test/data/test_abbreviations.py
@@ -1,5 +1,8 @@
 """
-TODO
+Unit tests for abbreviation helpers.
+
+These tests verify the mapping between team abbreviations and their
+corresponding location names, and vice versa.
 """
 
 import unittest
@@ -8,12 +11,12 @@ from src.data import abbreviations
 
 class TestAbbreviations(unittest.TestCase):
     """
-    TODO
+    Tests for `get_location` and `get_abbreviation` helper functions.
     """
 
     def test_get_location(self):
         """
-        TODO
+        Verify abbreviation-to-location mapping for valid and invalid inputs.
         """
         expected : str = "Anaheim"
         actual   : str = abbreviations.get_location("ANA")
@@ -29,7 +32,7 @@ class TestAbbreviations(unittest.TestCase):
 
     def test_get_abbreviation(self):
         """
-        TODO
+        Verify location-to-abbreviation mapping for valid and invalid inputs.
         """
         expected : str = "ANA"
         actual   : str = abbreviations.get_abbreviation("Anaheim")

--- a/test/data/test_event.py
+++ b/test/data/test_event.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 
 from src.data import event
 from src.data.period import Period
+from src.data.highlight import Highlight
 
 
 def make_period(number: int = 1) -> Period:
@@ -211,3 +212,63 @@ class TestEvent(unittest.TestCase):
         ))
 
         self.assertTrue(curr.is_secondary_assist_added(prev))
+
+
+class DummyTeam:
+    def __init__(self, location, abbreviation="", hashtag="", playoff_hashtag=""):
+        self.location = location
+        self.abbreviation = abbreviation
+        self.hashtag = hashtag
+        self.playoff_hashtag = playoff_hashtag
+
+
+class DummyGameData:
+    def __init__(self, home_location, away_location):
+        self.home = DummyTeam(home_location, "HOME", "#Home")
+        self.away = DummyTeam(away_location, "AWAY", "#Away")
+
+    def get_team_string(self, team):
+        if team == self.home.location:
+            return self.home.location
+        if team == self.away.location:
+            return self.away.location
+        return ""
+
+    @property
+    def hashtags(self):
+        return f"#{self.away.abbreviation}vs{self.home.abbreviation} {self.home.hashtag} {self.away.hashtag}"
+
+
+class TestHighlightShootout(unittest.TestCase):
+    """
+    Tests for formatting of highlight posts during special periods.
+    """
+
+    def test_shootout_goal_uses_shootout_template(self):
+        # Create a shootout period
+        period = Period(None, {"periodType": "SO", "number": 0})
+
+        # Minimal event data for a shootout goal
+        data = {
+            "timeInPeriod": "00:00",
+            "homeScore": 0,
+            "awayScore": 1,
+            "teamAbbrev": {"default": "EDM"},
+            "firstName": {"default": "John"},
+            "lastName": {"default": "Doe"},
+        }
+
+        evt = event.Event(period, data)
+
+        # Construct a dummy GameData-like object
+        game_data = DummyGameData("Edmonton", "Calgary")
+
+        # Create a Highlight instance without running __init__ (avoids network calls)
+        hl = Highlight.__new__(Highlight)
+        hl.event = evt
+        hl.game_data = game_data
+
+        post = hl.get_post()
+
+        # Ensure shootout wording appears in the generated post
+        self.assertIn(f"Scored by {evt.scorer} in the shootout.", post)

--- a/test/data/test_game_state.py
+++ b/test/data/test_game_state.py
@@ -1,5 +1,8 @@
 """
-TODO
+Unit tests for the `game_state` lookup mapping.
+
+These tests verify that the string codes map to the correct
+`GameState` enum values used throughout the application.
 """
 
 import unittest
@@ -9,12 +12,12 @@ from src.data import game_state
 
 class TestGameState(unittest.TestCase):
     """
-    TODO
+    Tests mapping of game state codes to the `GameState` enum.
     """
 
     def test_future(self):
         """
-        TODO
+        Lookup for the 'FUT' code returns GameState.FUTURE.
         """
         expected : game_state.GameState           = game_state.GameState.FUTURE
         actual   : Optional[game_state.GameState] = game_state.game_state_lookup.get("FUT")
@@ -22,7 +25,7 @@ class TestGameState(unittest.TestCase):
 
     def test_pregame(self):
         """
-        TODO
+        Lookup for the 'PRE' code returns GameState.PREGAME.
         """
         expected : game_state.GameState           = game_state.GameState.PREGAME
         actual   : Optional[game_state.GameState] = game_state.game_state_lookup.get("PRE")
@@ -30,7 +33,7 @@ class TestGameState(unittest.TestCase):
 
     def test_soft_final(self):
         """
-        TODO
+        Lookup for the 'OVER' code returns GameState.SOFT_FINAL.
         """
         expected : game_state.GameState           = game_state.GameState.SOFT_FINAL
         actual   : Optional[game_state.GameState] = game_state.game_state_lookup.get("OVER")
@@ -38,7 +41,7 @@ class TestGameState(unittest.TestCase):
 
     def test_hard_final(self):
         """
-        TODO
+        Lookup for the 'FINAL' code returns GameState.HARD_FINAL.
         """
         expected : game_state.GameState           = game_state.GameState.HARD_FINAL
         actual   : Optional[game_state.GameState] = game_state.game_state_lookup.get("FINAL")
@@ -46,7 +49,7 @@ class TestGameState(unittest.TestCase):
 
     def test_official(self):
         """
-        TODO
+        Lookup for the 'OFF' code returns GameState.OFFICIAL.
         """
         expected : game_state.GameState           = game_state.GameState.OFFICIAL
         actual   : Optional[game_state.GameState] = game_state.game_state_lookup.get("OFF")
@@ -54,7 +57,7 @@ class TestGameState(unittest.TestCase):
 
     def test_live(self):
         """
-        TODO
+        Lookup for the 'LIVE' code returns GameState.LIVE.
         """
         expected : game_state.GameState           = game_state.GameState.LIVE
         actual   : Optional[game_state.GameState] = game_state.game_state_lookup.get("LIVE")
@@ -62,7 +65,7 @@ class TestGameState(unittest.TestCase):
 
     def test_critical(self):
         """
-        TODO
+        Lookup for the 'CRIT' code returns GameState.CRITICAL.
         """
         expected : game_state.GameState           = game_state.GameState.CRITICAL
         actual   : Optional[game_state.GameState] = game_state.game_state_lookup.get("CRIT")

--- a/test/data/test_game_type.py
+++ b/test/data/test_game_type.py
@@ -1,5 +1,8 @@
 """
-TODO
+Unit tests for the `game_type` lookup and helper methods.
+
+These tests validate that numeric game type codes map to the
+correct `GameType` enum and that convenience predicates behave as expected.
 """
 
 import unittest
@@ -9,12 +12,12 @@ from src.data import game_type
 
 class TestGameType(unittest.TestCase):
     """
-    TODO
+    Tests for `GameType` lookup and predicate helpers.
     """
 
     def test_exhibition(self):
         """
-        TODO
+        Lookup for code 1 returns GameType.EXHIBITION.
         """
         expected : game_type.GameType           = game_type.GameType.EXHIBITION
         actual   : Optional[game_type.GameType] = game_type.game_type_lookup.get(1)
@@ -22,7 +25,7 @@ class TestGameType(unittest.TestCase):
 
     def test_regular_season(self):
         """
-        TODO
+        Lookup for code 2 returns GameType.REGULAR_SEASON.
         """
         expected : game_type.GameType           = game_type.GameType.REGULAR_SEASON
         actual   : Optional[game_type.GameType] = game_type.game_type_lookup.get(2)
@@ -30,7 +33,7 @@ class TestGameType(unittest.TestCase):
 
     def test_playoffs(self):
         """
-        TODO
+        Lookup for code 3 returns GameType.PLAYOFF.
         """
         expected : game_type.GameType           = game_type.GameType.PLAYOFF
         actual   : Optional[game_type.GameType] = game_type.game_type_lookup.get(3)
@@ -38,21 +41,21 @@ class TestGameType(unittest.TestCase):
 
     def test_is_exhibition(self):
         """
-        TODO
+        `is_exhibition()` returns True for EXHIBITION game type.
         """
         value : game_type.GameType = game_type.GameType.EXHIBITION
         assert value.is_exhibition()
 
     def test_is_regular_season(self):
         """
-        TODO
+        `is_regular_season()` returns True for REGULAR_SEASON game type.
         """
         value : game_type.GameType = game_type.GameType.REGULAR_SEASON
         assert value.is_regular_season()
 
     def test_is_playoffs(self):
         """
-        TODO
+        `is_playoff()` returns True for PLAYOFF game type.
         """
         value : game_type.GameType = game_type.GameType.PLAYOFF
         assert value.is_playoff()

--- a/test/data/test_period.py
+++ b/test/data/test_period.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for `Period` behavior: string conversions, ordinals, and lengths.
+"""
+
+import unittest
+from datetime import timedelta
+
+from src.data.period import Period
+from src.data.game_type import GameType
+
+
+class TestPeriod(unittest.TestCase):
+    """
+    Tests for `Period.__str__`, `Period.ordinal`, and `Period.length()`.
+    """
+
+    def test_str_regulation_and_special(self):
+        """
+        Regulation periods (1/2/3), overtime and shootout produce expected strings.
+        """
+        p1 = Period(None, {"periodType": "REG", "number": 1})
+        p2 = Period(None, {"periodType": "REG", "number": 2})
+        p3 = Period(None, {"periodType": "REG", "number": 3})
+        ot = Period(None, {"periodType": "OT", "number": 4})
+        so = Period(None, {"periodType": "SO", "number": 0})
+
+        self.assertEqual(str(p1), "The first period")
+        self.assertEqual(str(p2), "The second period")
+        self.assertEqual(str(p3), "The third period")
+        self.assertEqual(str(ot), "The OT period")
+        self.assertEqual(str(so), "The shootout")
+
+    def test_ordinal_values(self):
+        """
+        Ordinal labels for regulation, overtime sequences and shootout.
+        """
+        r1 = Period(None, {"periodType": "REG", "number": 1})
+        r2 = Period(None, {"periodType": "REG", "number": 2})
+        r3 = Period(None, {"periodType": "REG", "number": 3})
+        ot1 = Period(GameType.REGULAR_SEASON, {"periodType": "OT", "number": 4})
+        ot2 = Period(GameType.REGULAR_SEASON, {"periodType": "OT", "number": 5})
+        so = Period(None, {"periodType": "SO", "number": 0})
+
+        self.assertEqual(r1.ordinal, "1st")
+        self.assertEqual(r2.ordinal, "2nd")
+        self.assertEqual(r3.ordinal, "3rd")
+        self.assertEqual(ot1.ordinal, "OT")
+        self.assertEqual(ot2.ordinal, "2OT")
+        self.assertEqual(so.ordinal, "SO")
+
+    def test_length_varies_by_game_type(self):
+        """
+        Period.length returns expected timedeltas for regulation, shootout and OT variants.
+        """
+        reg = Period(None, {"periodType": "REG", "number": 1})
+        so = Period(None, {"periodType": "SO", "number": 0})
+
+        ot_regular = Period(GameType.REGULAR_SEASON, {"periodType": "OT", "number": 4})
+        ot_playoff = Period(GameType.PLAYOFF, {"periodType": "OT", "number": 4})
+        ot_four = Period(GameType.FOUR_NATIONS, {"periodType": "OT", "number": 4})
+
+        self.assertEqual(reg.length(), timedelta(minutes=20))
+        self.assertEqual(so.length(), timedelta(minutes=0))
+        self.assertEqual(ot_regular.length(), timedelta(minutes=5))
+        self.assertEqual(ot_playoff.length(), timedelta(minutes=20))
+        self.assertEqual(ot_four.length(), timedelta(minutes=10))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/data/test_score.py
+++ b/test/data/test_score.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for the `Score` simple data container.
+"""
+
+import unittest
+
+from src.data.score import Score
+
+
+class TestScore(unittest.TestCase):
+    """
+    Tests Score getters and setters.
+    """
+
+    def test_getters_and_setters(self):
+        """
+        Verify that home_goals and away_goals properties work.
+        """
+        data = {"homeScore": 2, "awayScore": 1}
+        s = Score(data)
+        self.assertEqual(s.home_goals, 2)
+        self.assertEqual(s.away_goals, 1)
+
+        s.home_goals = 5
+        s.away_goals = 4
+        self.assertEqual(s.home_goals, 5)
+        self.assertEqual(s.away_goals, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/output/test_bluesky_facets.py
+++ b/test/output/test_bluesky_facets.py
@@ -1,11 +1,22 @@
-import pytest
+"""
+Unit tests for Bluesky facet parsing utilities.
+
+These tests ensure hashtags are located correctly in byte offsets and
+that facet objects produced by `parse_tags` contain the expected data.
+"""
 
 from src.output.bluesky import get_tag_indices, parse_tags
 
 
 class TestBlueskyFacets:
+    """
+    Tests for tag index calculation and facets parsing.
+    """
 
     def test_single_ascii_hashtag(self):
+        """
+        Ensure a single ASCII hashtag is located and parsed correctly.
+        """
         text = "Goal by #McDavid"
 
         indices = get_tag_indices(text)
@@ -21,6 +32,9 @@ class TestBlueskyFacets:
         assert facets[0]["features"][0]["tag"] == "McDavid"
 
     def test_emoji_before_hashtag(self):
+        """
+        Ensure an emoji before a hashtag does not break byte indexing.
+        """
         text = "🚨 GOAL 🚨 by #McDavid"
 
         indices = get_tag_indices(text)
@@ -31,6 +45,9 @@ class TestBlueskyFacets:
         assert indices == [(byte_start, byte_end)]
 
     def test_accented_characters(self):
+        """
+        Ensure accented characters are handled when calculating byte offsets.
+        """
         text = "But à Montréal par #Suzuki"
 
         indices = get_tag_indices(text)
@@ -41,6 +58,9 @@ class TestBlueskyFacets:
         assert indices == [(byte_start, byte_end)]
 
     def test_multiple_hashtags(self):
+        """
+        Verify multiple hashtags in a string produce correct byte ranges.
+        """
         text = "🚨 #McDavid scores for the #Oilers"
 
         indices = get_tag_indices(text)
@@ -59,6 +79,9 @@ class TestBlueskyFacets:
         assert indices == expected
 
     def test_duplicate_hashtags(self):
+        """
+        Verify duplicate hashtags are reported separately with distinct ranges.
+        """
         text = "#Goal by #Goal scorer"
 
         indices = get_tag_indices(text)
@@ -71,6 +94,9 @@ class TestBlueskyFacets:
         assert facets[1]["features"][0]["tag"] == "Goal"
 
     def test_facet_byte_ranges_map_correctly(self):
+        """
+        Confirm byte ranges in facet objects map back to the original hashtag.
+        """
         text = "🚨 GOAL by #McDavid"
 
         facets = parse_tags(text)
@@ -88,6 +114,9 @@ class TestBlueskyFacets:
         assert extracted == "#McDavid"
 
     def test_get_tag_indices_single(self):
+        """
+        get_tag_indices returns a single range for a single hashtag.
+        """
         text = "This is a #test"
 
         byte_start = len("This is a ".encode("utf-8"))
@@ -99,6 +128,9 @@ class TestBlueskyFacets:
         assert expected == actual
 
     def test_get_tag_indices_multiple(self):
+        """
+        get_tag_indices returns multiple ranges for multiple hashtags.
+        """
         text = "#Hello world! This is a #test of #tags"
 
         expected = [
@@ -120,10 +152,16 @@ class TestBlueskyFacets:
         assert expected == actual
 
     def test_get_tag_indices_none(self):
+        """
+        get_tag_indices returns an empty list when no hashtags are present.
+        """
         text = "This text has no tags."
         assert get_tag_indices(text) == []
 
     def test_parse_tags_single(self):
+        """
+        parse_tags returns a single facet for a single hashtag.
+        """
         text = "This is a #test"
 
         facets = parse_tags(text)
@@ -132,6 +170,9 @@ class TestBlueskyFacets:
         assert facets[0]["features"][0]["tag"] == "test"
 
     def test_parse_tags_multiple(self):
+        """
+        parse_tags returns facets for each hashtag in the input.
+        """
         text = "#Hello world! This is a #test of #tags"
 
         facets = parse_tags(text)
@@ -140,5 +181,8 @@ class TestBlueskyFacets:
         assert tags == ["Hello", "test", "tags"]
 
     def test_parse_tags_none(self):
+        """
+        parse_tags returns an empty list when no hashtags are present.
+        """
         text = "This text has no tags."
         assert parse_tags(text) == []

--- a/test/output/test_printer.py
+++ b/test/output/test_printer.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for the `Printer` outputter.
+"""
+
+import unittest
+
+from src.output.printer import Printer
+
+
+class TestPrinter(unittest.TestCase):
+    """
+    Tests that Printer methods return an ID dict and do not raise.
+    """
+
+    def test_post_and_reply_return_ids(self):
+        """
+        post(), reply(), post_with_media(), reply_with_media() return dicts with 'id'.
+        """
+        p = Printer()
+        post_id = p.post("Hello")
+        self.assertIsInstance(post_id, dict)
+        self.assertIn("id", post_id)
+
+        reply_id = p.reply({"id": "123"}, "Hi")
+        self.assertIsInstance(reply_id, dict)
+        self.assertIn("id", reply_id)
+
+        pm = p.post_with_media("Hello", "media")
+        self.assertIsInstance(pm, dict)
+        self.assertIn("id", pm)
+
+        rm = p.reply_with_media({"id": "123"}, "Hi", "media")
+        self.assertIsInstance(rm, dict)
+        self.assertIn("id", rm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/output/test_templates.py
+++ b/test/output/test_templates.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for output templates formatting.
+"""
+
+import unittest
+
+from src.output import templates
+
+
+class TestTemplates(unittest.TestCase):
+    """
+    Ensure templates format and contain expected phrases.
+    """
+
+    def test_goal_template_contains_scorer(self):
+        """
+        GOAL_TEMPLATE should include 'Scored by {scorer}' after formatting.
+        """
+        values = {
+            "team": "Edmonton",
+            "scorer": "John Doe",
+            "time": "05:00",
+            "period": "1st",
+        }
+        text = templates.GOAL_TEMPLATE.format(**values)
+        self.assertIn("Scored by John Doe", text)
+
+    def test_shootout_template_wording(self):
+        """
+        SHOOTOUT_GOAL_TEMPLATE should mention the shootout.
+        """
+        values = {"team": "Edmonton", "scorer": "Jane", "time": "00:00", "period": "SO"}
+        text = templates.SHOOTOUT_GOAL_TEMPLATE.format(**values)
+        self.assertIn("in the shootout", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for utility helpers in `src.utils`.
+"""
+
+import unittest
+
+from src.utils import strip_text
+
+
+class TestUtils(unittest.TestCase):
+    """
+    Tests for `strip_text` behavior with matching and non-matching input.
+    """
+
+    def test_strip_text_matches_block(self):
+        """
+        When the text contains back-to-back score lines, they are returned combined.
+        """
+        text = "Header\nHome: 3\nAway: 2\nFooter"
+        result = strip_text(text)
+        self.assertEqual(result, "Home: 3 Away: 2")
+
+    def test_strip_text_no_match(self):
+        """
+        If no two-line score block exists, empty string is returned.
+        """
+        text = "No scores here"
+        result = strip_text(text)
+        self.assertEqual(result, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The bot has recently started posting shootout goals on its own - I think something in the API must've changed here. We're at least protecting ourselves here already, but the post text is a bit strange (referencing time left in a non-existent period). Let's update the message text to make this a little more coherent when shootout goals do get posted.